### PR TITLE
Remove warnings from spi.c and spi.h

### DIFF
--- a/freeRTOS10xx/include/spi.h
+++ b/freeRTOS10xx/include/spi.h
@@ -59,15 +59,15 @@ void spiSetClockDivider(SPI_CLOCK_DIV_t rate) __attribute__ ((flatten));
 void spiSetBitOrder(uint8_t bitOrder) __attribute__ ((flatten));
 void spiSetDataMode(SPI_MODE_t mode) __attribute__ ((flatten));
 
-void spiAttachInterrupt() __attribute__ ((flatten));
-void spiDetachInterrupt() __attribute__ ((flatten));
+void spiAttachInterrupt(void) __attribute__ ((flatten));
+void spiDetachInterrupt(void) __attribute__ ((flatten));
 
 uint8_t spiSelect (SPI_SLAVE_SELECT SS_pin) __attribute__ ((hot, flatten));
 void spiDeselect (SPI_SLAVE_SELECT SS_pin) __attribute__ ((hot, flatten));
 
 void spiBegin(SPI_SLAVE_SELECT SS_pin) __attribute__ ((flatten));
 
-void spiEnd() __attribute__ ((flatten));
+void spiEnd(void) __attribute__ ((flatten));
 
 /*
  * In testing with a Freetronics EtherMega driving an SD card

--- a/freeRTOS10xx/lib_io/spi.c
+++ b/freeRTOS10xx/lib_io/spi.c
@@ -118,7 +118,7 @@ void spiBegin(SPI_SLAVE_SELECT SS_pin)
     }
 }
 
-void spiEnd()
+void spiEnd(void)
 {
 	if( xSPISemaphore != NULL )
 		vQueueDelete( xSPISemaphore );		/* FreeRTOS semaphore */
@@ -148,12 +148,12 @@ void spiSetDataMode(SPI_MODE_t mode)
 }
 
 
-void spiAttachInterrupt()
+void spiAttachInterrupt(void)
 {
 	SPCR |= _BV(SPIE);
 }
 
-void spiDetachInterrupt()
+void spiDetachInterrupt(void)
 {
 	SPCR &= ~_BV(SPIE);
 }


### PR DESCRIPTION
Fixes 6 warnings in the SPI codebase: `warning: function declaration isn't a prototype`