### PR TITLE
fixed analog2digital conversion for channels > 7 (ATMega2560)

### DIFF
--- a/freeRTOS10xx/lib_io/digitalAnalog.c
+++ b/freeRTOS10xx/lib_io/digitalAnalog.c
@@ -88,6 +88,10 @@ inline void startAnalogConversion(uint8_t channel, uint8_t use_internal_referenc
 	}
 
 	tempADMUX &= ~0x1F;		 // clear channel selection bits of ADMUX
+    if(channel > 0x07){
+        ADCSRA |= _BV(MUX5);
+        channel &= 0x07;
+    }
 	tempADMUX |= channel;    // we only get this far if channel is less than 32
 	ADMUX = tempADMUX;
 	ADCSRA |= _BV(ADSC); // start the conversion


### PR DESCRIPTION
Hi, not sure if this is sufficient for other AVR devices, but I've tested it with ATMega2560 and it works. ATMega2560 has MUX5 bit in addition to MUX2:0 for selecting which ADC input is used. This pin needs to be set to 1 for channels 8-15.