### PR TITLE
fixed a register typo

### DIFF
--- a/freeRTOS10xx/lib_io/digitalAnalog.c
+++ b/freeRTOS10xx/lib_io/digitalAnalog.c
@@ -89,7 +89,7 @@ inline void startAnalogConversion(uint8_t channel, uint8_t use_internal_referenc
 
 	tempADMUX &= ~0x1F;		 // clear channel selection bits of ADMUX
     if(channel > 0x07){
-        ADCSRA |= _BV(MUX5);
+        ADCSRB |= _BV(MUX5);
         channel &= 0x07;
     }
 	tempADMUX |= channel;    // we only get this far if channel is less than 32


### PR DESCRIPTION
@feilipu I'm so sorry, I realised I made a typo in the register. The register for MUX5 bit is ADCSRB, not ADCSRA... My bad.